### PR TITLE
params.types is a string

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -372,19 +372,19 @@ TidalAPI.prototype._baseRequest = function(method, params, type, callback) {
       body = JSON.parse(body);
       if(params.types) {
         var newBody = {};
-        if(params.types.includes('tracks')) {
+        if(params.types.indexOf('tracks') > -1) {
           newBody['tracks'] = body.tracks;
         }
-        if(params.types.includes('artists')) {
+        if(params.types.indexOf('artists') > -1) {
           newBody['artists'] = body.artists;
         }
-        if(params.types.includes('albums')) {
+        if(params.types.indexOf('albums') > -1) {
           newBody['albums'] = body.albums;
         }
-        if(params.types.includes('videos')) {
+        if(params.types.indexOf('videos') > -1) {
           newBody['videos'] = body.videos;
         }
-        if(params.types.includes('playlists')) {
+        if(params.types.indexOf('playlists') > -1) {
           newBody['playlists'] = body.playlists;
         }
         callback(newBody);


### PR DESCRIPTION
Fix for the following error on Node.js v0.12.7:

```
Patricks-MacBook-Air:examples pschroen$ node -v
v0.12.7
Patricks-MacBook-Air:examples pschroen$ node search
https://resources.wimpmusic.com/images/24f52ab0/e7d6/414d/a650/20a4c686aa57/1280x1280.jpg
/Users/pschroen/TidalAPI/lib/client.js:375
        if(params.types.includes('tracks')) {
                        ^
TypeError: undefined is not a function
    at Request._callback (/Users/pschroen/TidalAPI/lib/client.js:375:25)
    at Request.self.callback (/Users/pschroen/TidalAPI/node_modules/request/request.js:200:22)
    at Request.emit (events.js:110:17)
    at Request.<anonymous> (/Users/pschroen/TidalAPI/node_modules/request/request.js:1067:10)
    at Request.emit (events.js:129:20)
    at IncomingMessage.<anonymous> (/Users/pschroen/TidalAPI/node_modules/request/request.js:988:12)
    at IncomingMessage.emit (events.js:129:20)
    at _stream_readable.js:908:16
    at process._tickCallback (node.js:355:11)
```